### PR TITLE
Fix double string serialization in s3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject adikteev/duratom "0.3.3"
+(defproject duratom "0.3.3"
   :description "A durable atom type for Clojure."
   :url "https://github.com/jimpil/duratom"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject duratom "0.3.3"
+(defproject adikteev/duratom "0.3.3"
   :description "A durable atom type for Clojure."
   :url "https://github.com/jimpil/duratom"
   :license {:name "Eclipse Public License"
@@ -8,4 +8,6 @@
                                   [org.postgresql/postgresql "9.4.1208.jre7"] ;; PGSQL driver
                                   [amazonica "0.3.58"]]}}
   ;:aot :all
+  :lein-release {:deploy-via :clojars}
+
   )

--- a/src/duratom/backends.clj
+++ b/src/duratom/backends.clj
@@ -52,7 +52,7 @@
 ;;==========================<AMAZON-S3>=============================================
 
 (defn- save-to-s3! [credentials bucket k state-atom]
-  (ut/store-value-to-s3 credentials bucket k (pr-str @state-atom))
+  (ut/store-value-to-s3 credentials bucket k @state-atom)
   state-atom)
 
 (defrecord S3Backend [credentials bucket k committer]


### PR DESCRIPTION
Hey dude, the s3 backend serializes the atom twice (the second being in utils/store-to-s3) and so the reader can't read edn afterwards.

Here's a simple fix.

To test it : 

``` bash
echo "{:init true}" > stuff && aws s3 cp stuff s3://mybucket
```

``` clojure
(defn my-duratom (duratom :aws-s3
                 :credentials {:access-key (env :s3-access-key)
                               :secret-key (env :s3-secret-key)}
                 :bucket "mybucket"
                 :key "stuff"
                 :init {:init true}))

(swap! my-duratom assoc :bla "bla")
```

``` bash
aws s3 cp s3://mybucke/stuff cp stuff-r && cat stuff-r
```
