### PR TITLE
Feature/redis support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ If you are perfectly content with losing metadata and want to revert to the prev
 - [clojure.java.jdbc](https://github.com/clojure/java.jdbc) >= 0.6.0
 - [amazonica](https://github.com/mcohen01/amazonica)
 
+## Development
+
+Start databases with a command `docker-compose up` before running the tests
+
 ## License
 
 Copyright © 2016 Dimitrios Piliouras

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ In order to provide durability `duratom` will persist its state to some durable-
  1. A file on the local file-system
  2. A postgres DB table row
  3. An AWS-S3 bucket key
+ 4. A Redis DB key
 
 Note: Several ideas taken/adapted/combined from [enduro](https://github.com/alandipert/enduro) & [durable-atom](https://github.com/polygloton/durable-atom)
 
@@ -53,6 +54,12 @@ Subsequent mutating operations are prohibited (only `deref`ing will work).
          :bucket "my_bucket"
          :key "0"
          :init {:x 1 :y 2})
+
+;; backed by Redis
+(duratom :redis-db
+         :db-config "any db-spec as understood by carmine"
+         :key-name "my:key"
+         :init {:x 1 :y 2})
 ```
 
 The initial-value <init> can be a concrete value (as show above), but also a no-arg fn or a delay. In any case, it may end up being completely ignored (i.e. if the underlying persistent storage is found to be non-empty).
@@ -89,6 +96,13 @@ By default duratom stores plain EDN data (via `pr-str`). If that's good enough f
          :rw {:read (comp nippy/thaw utils/s3-bucket-bytes)
               :write nippy/freeze})          
 
+;;Carmine uses Nippy under the hood for Redis when Clojure types are passed in directly
+(duratom :redis-db
+         :db-config "any db-spec as understood by carmine"
+         :key-name "my:key"
+         :init {:x 1 :y 2}
+         :rw {:read identity
+              :write identity})
 ```
 
 ## Asynchronous commits (by default)
@@ -119,6 +133,7 @@ If you are perfectly content with losing metadata and want to revert to the prev
 
 - [clojure.java.jdbc](https://github.com/clojure/java.jdbc) >= 0.6.0
 - [amazonica](https://github.com/mcohen01/amazonica)
+- [carmine](https://github.com/ptaoussanis/carmine)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In order to provide durability `duratom` will persist its state to some durable-
  1. A file on the local file-system
  2. A postgres DB table row
  3. An AWS-S3 bucket key
- 4. A Redis DB key
+ 4. A Redis DB key (*)
 
 Note: Several ideas taken/adapted/combined from [enduro](https://github.com/alandipert/enduro) & [durable-atom](https://github.com/polygloton/durable-atom)
 
@@ -25,6 +25,8 @@ Main difference between `duratom` & `enduro` is that an `enduro` atom is not a d
   2. it requires the watches/validators to be provided in atoms upon construction.
 
 Main difference between `duratom` & `durable-atom` is that a `durable-atom` atom doesn't have a second level of polymorphism to accommodate for switching storage backends. It assumes that a file-backed atom is always what you want. Moreover, it uses `slurp` & `spit` for reading/writing to the disk, which, in practice, puts a limit on how big data-structures you can fit in a String (depending on your hardware & JVM configuration of course). Finally, it uses `locking` which is problematic on some JVMs (e.g. certain IBM JVM versions). `duratom` uses the `java.util.concurrent.locks.Lock` interface instead.
+
+(*) Redis is an in-memory data structure store with optional persistence. It might not be the best option in those cases where you absolutely cannot lose the state backed by `duratom`. In other use cases it is a fast, flexible and lightweight backend option for the durable atom.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,15 @@ If you are perfectly content with losing metadata and want to revert to the prev
 
 ## Development
 
-Start databases with a command `docker-compose up` before running the tests
+Tests require PostreSQL and Redis server installed on your machine.
+
+Another option is to use the provided Docker compose configuration in a following way:
+
+1. Install [Docker](https://docs.docker.com/install)
+2. Install [Docker Compose](https://docs.docker.com/compose/install/)
+3. Start all databases with command `docker-compose up`
+4. Now you can run tests freely
+5. When you are finished with the development stop the database by running `docker-compose down`
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.3'
+
+services:
+  postgres:
+    image: postgres
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=atomDB
+      - POSTGRES_USER=dimitris
+      - POSTGRES_PASSWORD=secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,8 @@ services:
       - POSTGRES_DB=atomDB
       - POSTGRES_USER=dimitris
       - POSTGRES_PASSWORD=secret
+  redis:
+    container_name: redis
+    image: redis
+    ports:
+      - "6379:6379"

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                                   [org.clojure/java.jdbc "0.6.1"]
                                   [org.postgresql/postgresql "9.4.1208.jre7"] ;; PGSQL driver
                                   [amazonica "0.3.58"]
+                                  [com.taoensso/carmine "2.19.1"]
                                   [com.taoensso/nippy "2.13.0"]]}}
   :source-paths ["src/clojure"]
   :java-source-paths ["src/java"]

--- a/src/clojure/duratom/backends.clj
+++ b/src/clojure/duratom/backends.clj
@@ -77,3 +77,16 @@
   (cleanup [_]
     (ut/delete-object-from-s3 credentials bucket k)) ;;drop the whole object
   )
+
+;;==========================<REDIS>=============================================
+
+(defrecord RedisBackend [conn key-name read-it! write-it! committer]
+  IStorageBackend
+  (snapshot [_]
+    (read-it! (ut/redis-get conn key-name)))
+  (commit [_]
+    (commit! committer (fn [state-atom]
+                         (ut/redis-set conn key-name (write-it! @state-atom))
+                         state-atom)))
+  (cleanup [_]
+    (ut/redis-del conn key-name)))

--- a/src/clojure/duratom/core.clj
+++ b/src/clojure/duratom/core.clj
@@ -262,8 +262,10 @@
                    (select-keys rw [:commit-mode])))))
 
 (def default-redis-rw
-  {:read  identity ;Redis library Carmine automatically uses Nippu for serialization/deserialization
-   :write identity ;Redis library Carmine automatically uses Nippu for serialization/deserialization
+  {;; Redis library Carmine automatically uses Nippy for serialization/deserialization Clojure types
+   ;; So by just replacing these functions with `identity` they will be serialized with Nippy
+   :read  ut/read-edn-string
+   :write (partial ut/pr-str-fully true)
    :commit-mode DEFAULT_COMMIT_MODE}) ;; technically not needed but leaving it for transparency)
 
 (defn redis-atom [db-config key-name lock initial-value rw]

--- a/src/clojure/duratom/not_found/redis.clj
+++ b/src/clojure/duratom/not_found/redis.clj
@@ -1,0 +1,25 @@
+(ns duratom.not-found.redis)
+
+(defmacro wcar [conn-opts & args]
+  `(throw (UnsupportedOperationException.
+              "Redis backend requires that you have `com.taoensso/carmine` on your classpath...")))
+
+(defn exists
+  [key-name]
+  (throw (UnsupportedOperationException.
+           "Redis backend requires that you have `com.taoensso/carmine` on your classpath...")))
+
+(defn get
+  [key-name]
+  (throw (UnsupportedOperationException.
+           "Redis backend requires that you have `com.taoensso/carmine` on your classpath...")))
+
+(defn set
+  [key-name value]
+  (throw (UnsupportedOperationException.
+           "Redis backend requires that you have `com.taoensso/carmine` on your classpath...")))
+
+(defn del
+  [key-name]
+  (throw (UnsupportedOperationException.
+           "Redis backend requires that you have `com.taoensso/carmine` on your classpath...")))

--- a/src/clojure/duratom/utils.clj
+++ b/src/clojure/duratom/utils.clj
@@ -22,6 +22,11 @@
   (catch Exception e
     (require '[duratom.not-found.s3 :as aws])))
 
+(try
+  (require '[taoensso.carmine :as car])
+  (catch Exception e
+    (require '[duratom.not-found.redis :as car])))
+
 (defn iobj->edn-tag
   "Helper fn for constructing ObjectWithMeta wrapper.
    An object of this type will essentially be serialised
@@ -205,3 +210,17 @@
 
 (defn bucket-exists? [creds bucket-name]
   (aws/does-bucket-exist creds bucket-name))
+
+;;===============<REDIS-UTILS>=====================================
+
+(defn redis-get [db-config key-name]
+  (car/wcar db-config (car/get key-name)))
+
+(defn redis-set [db-config key-name value]
+  (car/wcar db-config (car/set key-name value)))
+
+(defn redis-del [db-config key-name]
+  (car/wcar db-config (car/del key-name)))
+
+(defn redis-key-exists? [db-config key-name]
+  (= 1 (car/wcar db-config (car/exists key-name))))

--- a/test/duratom/core_test.clj
+++ b/test/duratom/core_test.clj
@@ -120,7 +120,7 @@
   (let [db-spec {:classname   "org.postgresql.Driver"
                  :subprotocol "postgresql"
                  :subname     "//localhost:5432/atomDB"
-                 :username    "dimitris"
+                 :user        "dimitris"
                  :password    "secret"}
         table-name "atom_state"
         _ (ut/delete-relevant-row! db-spec table-name 0)
@@ -203,7 +203,7 @@
     (let [db-spec {:classname   "org.postgresql.Driver"
                    :subprotocol "postgresql"
                    :subname     "//localhost:5432/atomDB"
-                   :username    "dimitris"
+                   :user        "dimitris"
                    :password    "secret"}
           table-name "atom_state_bytes"
           init {:x 1 :y 2}

--- a/test/duratom/core_test.clj
+++ b/test/duratom/core_test.clj
@@ -185,7 +185,7 @@
              key-exists?
              async?)
     ;; with contents
-    (ut/redis-set db-config key-name init)
+    (ut/redis-set db-config key-name (pr-str init))
     (common* (duratom :redis-db
                       :db-config db-config
                       :key-name key-name
@@ -274,5 +274,34 @@
                true)
       )
     )
-  )
+
+  (testing "Redis DB-backed atom containing `nippy` bytes..."
+    (let [db-config  {:pool {} :spec {:uri "redis://localhost/"}}
+          key-name "atom:state:bytes"
+          key-exists? #(ut/redis-key-exists? db-config key-name)
+          init {:x 1 :y 2}
+          dura (duratom :redis-db
+                        :db-config db-config
+                        :key-name key-name
+                        :init init
+                        :rw {:read  identity
+                             :write identity})]
+
+      ;; empty row first
+      (common* dura
+               key-exists?
+               true)
+      ;; with-contents thereafter
+      (ut/redis-set db-config key-name init)
+      (common* (duratom :redis-db
+                        :db-config db-config
+                        :key-name key-name
+                        :init init
+                        :rw {:read  identity
+                             :write identity})
+               key-exists?
+               true)
+      )
+    )
+)
 


### PR DESCRIPTION
Here is PR for Redis support. The data will be stored to a single Redis key using Nippy serialisation. This is a different default setting than with other backends. However, de-facto Clojure client Carmine already uses Nippy under the hood so I thought this would make sense.

For testing purposes I added a docker-compose configuration for easily setting up multiple databases. I am not sure if you like this approach. It makes it easy to run units tests without installing all the required dbs locally.